### PR TITLE
Lower the minimum version for typing-extensions by 1 version (4.8.0 -> 4.7.1)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -716,13 +716,13 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.6.0)", "pre-commit", "pytest (>=7.0,
 
 [[package]]
 name = "typing-extensions"
-version = "4.8.0"
+version = "4.7.1"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.8.0-py3-none-any.whl", hash = "sha256:8f92fc8806f9a6b641eaa5318da32b44d401efaac0f6678c9bc448ba3605faa0"},
-    {file = "typing_extensions-4.8.0.tar.gz", hash = "sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"},
+    {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
+    {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ authors = ["suned <sd@dybro-debel.dk>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
-typing-extensions = "^4.8.0"
+python = "^3.9"
+typing-extensions = ">=4.7.1"
 cloudpickle = "^3.0.0"
 
 


### PR DESCRIPTION
This allows stateless to be imported in the browser:

https://jupyterlite.readthedocs.io/en/stable/_static/lab/index.html